### PR TITLE
Add current IP JSCS configuration

### DIFF
--- a/files/.jscsrc
+++ b/files/.jscsrc
@@ -1,0 +1,63 @@
+{
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch"
+  ],
+  "requireOperatorBeforeLineBreak": true,
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
+  "maximumLineLength": {
+    "value": 120,
+    "allowComments": true,
+    "allowRegex": true
+  },
+  "validateIndentation": 2,
+  "validateQuoteMarks": "'",
+
+  "disallowMultipleLineStrings": true,
+  "disallowMixedSpacesAndTabs": true,
+  "disallowTrailingWhitespace": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "disallowMultipleVarDecl": true,
+  "disallowKeywordsOnNewLine": ["else"],
+
+  "requireSpaceAfterKeywords": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "return",
+    "try",
+    "catch"
+  ],
+  "requireSpaceBeforeBinaryOperators": [
+    "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=",
+    "&=", "|=", "^=", "+=",
+    "+", "-", "*", "/", "%", "<<", ">>", ">>>", "&",
+    "|", "^", "&&", "||", "===", "==", ">=",
+    "<=", "<", ">", "!=", "!=="
+  ],
+  "requireSpaceAfterBinaryOperators": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpacesInForStatement": true,
+  "requireLineFeedAtFileEnd": true,
+  "requireSpacesInFunctionExpression": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInsideObjectBrackets": "all",
+  "disallowSpacesInsideArrayBrackets": "all",
+  "disallowSpacesInsideParentheses": true,
+
+  "disallowMultipleLineBreaks": true,
+  "disallowNewlineBeforeBlockStatements": true
+}

--- a/index.html
+++ b/index.html
@@ -22,5 +22,5 @@ layout: default
 <p>Following configuration files can be used in accordance to the coding conventions:</p>
 <ul>
   <li><a href="/files/.jshintrc">.jshintrc</a> for <a href="https://github.com/jshint/jshint">JSHint</a></li>
-  <li><a href="https://raw.githubusercontent.com/jscs-dev/node-jscs/master/presets/google.json">.jscsrc</a> for <a href="http://jscs.info/">JSCS</a></li>
+  <li><a href="/files/.jscsrcs">.jscsrc</a> for <a href="http://jscs.info/">JSCS</a></li>
 </ul>


### PR DESCRIPTION
Since we've changed the default Google JSCS configuration, we need to establish a common standard that can be used for all our tooling, e.g. `iptools`.

One of the major topics to decide is line length. 120 (our current) vs 80 (Google). Pros and cons? Opinions please @GeorgMeyer23 @beroes @davidyezsetz.