### PR TITLE
Feature/scss sass lint

### DIFF
--- a/files/.sass-lint.yml
+++ b/files/.sass-lint.yml
@@ -1,0 +1,360 @@
+files:
+  include: '**/*.scss'
+options:
+  formatter: stylish
+  merge-default-rules: false
+rules:
+  attribute-quotes:
+    - 0
+    - include: true
+  bem-depth:
+    - 1
+    - max-depth: 2
+  border-zero:
+    - 1
+    - convention: zero
+  brace-style:
+    - 1
+    - allow-single-line: true
+  class-name-format:
+    - 0
+    - convention: hyphenatedbem
+  clean-import-paths:
+    - 1
+    - filename-extension: false
+      leading-underscore: false
+  declarations-before-nesting: 1
+  empty-args:
+    - 0
+    - include: false
+  empty-line-between-blocks:
+    - 1
+    - ignore-single-line-rulesets: true
+  extends-before-declarations: 1
+  extends-before-mixins: 1
+  final-newline:
+    - 1
+    - include: true
+  force-attribute-nesting: 0
+  force-element-nesting: 0
+  force-pseudo-nesting: 0
+  function-name-format:
+    - 0
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+  hex-length:
+    - 1
+    - style: short
+  hex-notation:
+    - 1
+    - style: lowercase
+  id-name-format:
+    - 0
+    - convention: hyphenatedbem
+  indentation:
+    - 1
+    - size: 2
+  leading-zero:
+    - 1
+    - include: true
+  max-file-line-count:
+    - 0
+    - length: 300
+  max-line-length:
+    - 0
+    - length: 80
+  mixin-name-format:
+    - 0
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+  mixins-before-declarations: 1
+  nesting-depth:
+    - 1
+    - max-depth: 8
+  no-attribute-selectors: 0
+  no-color-hex: 0
+  no-color-keywords: 1
+  no-color-literals: 0
+  no-combinators: 0
+  no-css-comments: 0
+  no-debug: 1
+  no-disallowed-properties: 0
+  no-duplicate-properties: 1
+  no-empty-rulesets: 1
+  no-extends: 0
+  no-ids: 1
+  no-important: 1
+  no-invalid-hex: 1
+  no-mergeable-selectors: 1
+  no-misspelled-properties:
+    - 1
+    - extra-properties: []
+  no-qualifying-elements:
+    - 1
+    - allow-element-with-attribute: true
+      allow-element-with-class: false
+      allow-element-with-id: false
+  no-trailing-whitespace: 1
+  no-trailing-zero: 1
+  no-transition-all: 1
+  no-universal-selectors: 0
+  no-url-domains: 1
+  no-url-protocols:
+    - 1
+    - allow-protocol-relative-urls: false
+  no-vendor-prefixes:
+    - 1
+    - additional-identifiers: []
+      excluded-identifiers: []
+  no-warn: 0
+  one-declaration-per-line: 1
+  placeholder-in-extend: 1
+  placeholder-name-format:
+    - 0
+    - convention: hyphenatedbem
+  property-sort-order:
+    - 1
+    - ignore-custom-properties: false
+      order:
+        - position
+        - top
+        - right
+        - bottom
+        - left
+        - z-index
+        - float
+        - clear
+        - null
+        - display
+        - overflow
+        - overflow-x
+        - overflow-y
+        - box-sizing
+        - margin
+        - margin-top
+        - margin-right
+        - margin-bottom
+        - margin-left
+        - padding
+        - padding-top
+        - padding-right
+        - padding-bottom
+        - padding-left
+        - width
+        - min-width
+        - max-width
+        - height
+        - min-height
+        - max-height
+        - border-collapse
+        - border-spacing
+        - border
+        - border-width
+        - border-style
+        - border-color
+        - border-top
+        - border-top-width
+        - border-top-style
+        - border-top-color
+        - border-right
+        - border-right-width
+        - border-right-style
+        - border-right-color
+        - border-bottom
+        - border-bottom-width
+        - border-bottom-style
+        - border-bottom-color
+        - border-left
+        - border-left-width
+        - border-left-style
+        - border-left-color
+        - flex
+        - flex-flow
+        - flex-direction
+        - flex-wrap
+        - flex-grow
+        - flex-shrink
+        - flex-basis
+        - justify-content
+        - align-items
+        - align-content
+        - align-self
+        - order
+        - table-layout
+        - caption-side
+        - empty-cells
+        - columns
+        - column-gap
+        - column-fill
+        - column-rule
+        - column-span
+        - column-count
+        - column-width
+        - clip
+        - clip-path
+        - null
+        - visibility
+        - opacity
+        - border-radius
+        - border-top-left-radius
+        - border-top-right-radius
+        - border-bottom-right-radius
+        - border-bottom-left-radius
+        - border-image
+        - border-image-source
+        - border-image-slice
+        - border-image-width
+        - border-image-outset
+        - border-image-repeat
+        - outline
+        - outline-color
+        - outline-offset
+        - outline-style
+        - outline-width
+        - background
+        - background-color
+        - background-image
+        - background-repeat
+        - background-attachment
+        - background-position
+        - background-position-x
+        - background-position-y
+        - background-origin
+        - background-size
+        - background-clip
+        - box-shadow
+        - filter
+        - null
+        - color
+        - font
+        - font-family
+        - font-size
+        - font-size-adjust
+        - font-smoothing
+        - font-style
+        - font-variant
+        - font-weight
+        - line-height
+        - vertical-align
+        - direction
+        - text-align
+        - text-align-last
+        - text-decoration
+        - text-indent
+        - text-overflow
+        - text-rendering
+        - text-shadow
+        - text-size-adjust
+        - text-transform
+        - text-wrap
+        - word-wrap
+        - overflow-wrap
+        - letter-spacing
+        - word-spacing
+        - word-break
+        - hyphens
+        - white-space
+        - tab-size
+        - list-style
+        - list-style-position
+        - list-style-type
+        - list-style-image
+        - null
+        - transform
+        - transform-function
+        - transform-origin
+        - transform-style
+        - perspective
+        - perspective-origin
+        - backface-visibility
+        - null
+        - transition
+        - transition-property
+        - transition-duration
+        - transition-timing-function
+        - transition-delay
+        - animation
+        - animation-name
+        - animation-duration
+        - animation-timing-function
+        - animation-delay
+        - animation-iteration-count
+        - animation-direction
+        - animation-fill-mode
+        - animation-play-state
+        - null
+        - cursor
+        - pointer-events
+        - resize
+        - user-select
+  property-units:
+    - 1
+    - global:
+        - ch
+        - em
+        - ex
+        - rem
+        - cm
+        - in
+        - mm
+        - pc
+        - pt
+        - px
+        - q
+        - vh
+        - vw
+        - vmin
+        - vmax
+        - deg
+        - grad
+        - rad
+        - turn
+        - ms
+        - s
+        - Hz
+        - kHz
+        - dpi
+        - dpcm
+        - dppx
+        - '%'
+      per-property: {}
+  pseudo-element: 1
+  quotes:
+    - 1
+    - style: single
+  shorthand-values: 0
+  single-line-per-selector: 1
+  space-after-bang:
+    - 1
+    - include: false
+  space-after-colon:
+    - 1
+    - include: true
+  space-after-comma:
+    - 1
+    - include: true
+  space-around-operator:
+    - 1
+    - include: true
+  space-before-bang:
+    - 1
+    - include: true
+  space-before-brace:
+    - 1
+    - include: true
+  space-before-colon:
+    - 1
+    - include: true
+  space-between-parens:
+    - 1
+    - include: false
+  trailing-semicolon: 1
+  url-quotes: 1
+  variable-for-property:
+    - 0
+    - properties: []
+  variable-name-format:
+    - 0
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+  zero-unit: 1

--- a/files/.sass-lint.yml
+++ b/files/.sass-lint.yml
@@ -1,5 +1,6 @@
 files:
   include: '**/*.scss'
+  #ignore:
 options:
   formatter: stylish
   merge-default-rules: false
@@ -67,7 +68,9 @@ rules:
     - 0
     - allow-leading-underscore: true
       convention: hyphenatedlowercase
-  mixins-before-declarations: 1
+  mixins-before-declarations:
+    - 1
+    - exclude: ['media-query', 'hover']
   nesting-depth:
     - 1
     - max-depth: 8
@@ -88,14 +91,14 @@ rules:
   no-mergeable-selectors: 1
   no-misspelled-properties:
     - 1
-    - extra-properties: []
+    - extra-properties: ['overflow-scrolling']
   no-qualifying-elements:
     - 1
     - allow-element-with-attribute: true
       allow-element-with-class: false
       allow-element-with-id: false
   no-trailing-whitespace: 1
-  no-trailing-zero: 1
+  no-trailing-zero: 0
   no-transition-all: 1
   no-universal-selectors: 0
   no-url-domains: 1
@@ -343,8 +346,8 @@ rules:
     - 1
     - include: true
   space-before-colon:
-    - 1
-    - include: true
+    - 0
+    - include: false
   space-between-parens:
     - 1
     - include: false

--- a/files/.scss-lint.yml
+++ b/files/.scss-lint.yml
@@ -1,8 +1,4 @@
-scss_files: "**/*.scss"
-
-# exclude third party libs
-exclude:
-  #- 'path/to/file.scss'
+scss_files: '**/*.scss'
 
 linters:
   BangFormat:
@@ -16,7 +12,10 @@ linters:
 
   BorderZero:
     enabled: true
-    convention: zero # or `none`
+    convention: zero # or 'none'
+
+  ChainedClasses:
+    enabled: false
 
   ColorKeyword:
     enabled: true
@@ -32,13 +31,20 @@ linters:
 
   DeclarationOrder:
     enabled: true
-
-  # enable support for older browser (calc)
-  DuplicateProperty:
+  
+  # scss-lint:disable control comments should be preceded by a comment explaining why these linters are being disabled for this file.
+  # disabled because not yet supported by sass-lint
+  DisableLinterReason:
     enabled: false
 
+  # ignore_consecutive option not yet supported by sass-lint
+  DuplicateProperty:
+    enabled: false
+    ignore_consecutive: true
+
+  # disabled because not yet supported by sass-lint
   ElsePlacement:
-    enabled: true
+    enabled: false
     style: same_line # or 'new_line'
 
   EmptyLineBetweenBlocks:
@@ -87,9 +93,13 @@ linters:
     enabled: true
     style: include_zero # or 'exclude_zero'
 
+  LengthVariable:
+    enabled: false
+
   MergeableSelector:
     enabled: true
     force_nesting: false
+    # whitelist:
 
   NameFormat:
     enabled: false
@@ -104,6 +114,12 @@ linters:
   PlaceholderInExtend:
     enabled: true
 
+  PrivateNamingConvention:
+    enabled: false
+    prefix: _
+
+  # Limit the number of properties in a rule set.
+  # not yet supported by sass-lint
   PropertyCount:
     enabled: false
     include_nested: false
@@ -305,19 +321,23 @@ linters:
     enabled: true
     extra_properties: []
 
+  PseudoElement:
+    enable: true
+
   QualifyingElement:
     enabled: true
     allow_element_with_attribute: true
     allow_element_with_class: false
     allow_element_with_id: false
 
+  # not yet supported by sass-lint
   SelectorDepth:
-    enabled: true
+    enabled: false
     max_depth: 3
 
   SelectorFormat:
     enabled: false
-    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+    convention: hyphenated_BEM # or 'strict_BEM', or 'hyphenated_lowercase', or 'snake_case', or 'camel_case', or a regex pattern
 
   Shorthand:
     enabled: false
@@ -333,12 +353,28 @@ linters:
   SpaceAfterComma:
     enabled: true
 
+  # disabled because not yet supported by sass-lint
+  SpaceAfterComment:
+    enabled: false
+    style: one_space
+
   SpaceAfterPropertyColon:
     enabled: true
     style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
 
   SpaceAfterPropertyName:
     enabled: true
+
+  SpaceAfterVariableColon:
+    enabled: true
+    style: one_space
+
+  SpaceAfterVariableName:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space
 
   SpaceBeforeBrace:
     enabled: true
@@ -362,11 +398,16 @@ linters:
   TrailingZero:
     enabled: false
 
+  TransitionAll:
+    enabled: true
+
   UnnecessaryMantissa:
     enabled: true
 
+  # Do not use parent selector references (&) when they would otherwise be unnecessary.
+  # disabled because not yet supported by sass-lint
   UnnecessaryParentReference:
-    enabled: true
+    enabled: false
 
   UrlFormat:
     enabled: true


### PR DESCRIPTION
Converted the current .scss-lint.yml to .sass-lint.yml.
Needed to relax / disable some rules to get them in sync.

Biggest issue: Linting SelectorDepth is not supported by .sass-lint.yml. Our conventions say, that the selector depth is 3 at maximum (.a .b .c {}), .sass-lint.yml can only check for nesting depth, which is something different.

Perhaps we should also discuss the sort order again at this point. I would make some minor adjustments, perhaps we can skip the last block?