### PR TITLE
Add Mocha option to JavaScript linting config

### DIFF
--- a/files/.jshintrc
+++ b/files/.jshintrc
@@ -18,5 +18,6 @@
   "strict": true,
   "trailing": true,
   "smarttabs": true,
-  "jquery": false
+  "jquery": false,
+  "mocha": true
 }


### PR DESCRIPTION
Prevent defining describe, context, it globals as per file.
As Mocha has been de facto testing framework such a default would make
sense.